### PR TITLE
fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
@@ -30,5 +30,5 @@ facere-sensum = "facere_sensum.facere_sensum:main"
 [tool.hatch.version]
 path = "src/facere_sensum/facere_sensum.py"
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]

--- a/src/facere_sensum/facere_sensum.py
+++ b/src/facere_sensum/facere_sensum.py
@@ -9,7 +9,7 @@ import datetime
 import numpy as np
 import pandas as pd
 
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 
 def score_manual(metric):
     '''


### PR DESCRIPTION
Looks like previous dependencies implementation was not very official and broke as toolchains upgraded.
This PR uses a plugin built exactly for this purpose: https://pypi.org/project/hatch-requirements-txt
