### PR TITLE
Enabling code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = src
+parallel = True
+branch = True

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run Pylint static code analyser
         run: |
-          pip install pylint
+          pip install coverage pylint
           pylint src/facere_sensum test
       - name: Run Bandit security analyser
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHONPATH: src
+  PYTHONPATH: src:test
+  COVERAGE_PROCESS_START: .coveragerc
 
 jobs:
   tests:
@@ -23,5 +24,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run tests
-        run: python test/test.py
+      - name: Run tests with coverage
+        run: |
+          pip install coverage
+          python test/test.py
+          coverage combine
+          coverage report --fail-under=90
+          coverage xml coverage.xml
+
+      - name: Report code coverage for PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: orgoro/coverage@v3.1
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/facere_sensum/facere_sensum.py
+++ b/src/facere_sensum/facere_sensum.py
@@ -4,6 +4,7 @@
 facere-sensum: make sense of the turmoil.
 '''
 
+import sys
 from argparse import ArgumentParser
 import datetime
 import numpy as np
@@ -11,7 +12,7 @@ import pandas as pd
 
 VERSION = '0.0.4'
 
-def score_manual(metric):
+def score_manual(metric): # pragma: no cover - function is replaced by automated data in tests
     '''
     Get metric score as a direct user input.
     'metric' is the metric text description.
@@ -44,7 +45,11 @@ def score_combined(log_file, marker):
     Return combined score.
     'marker' is the identificator to be used with the scoring (e.g., the date of data collection).
     '''
-    data = pd.read_csv(log_file)
+    try:
+        data = pd.read_csv(log_file)
+    except FileNotFoundError:
+        print('Log file \''+log_file+'\' not found. Exiting.')
+        sys.exit(1)
 
     # Infer metrics from priority column names.
     metrics = [s[2:-1] for s in data.columns[1:-1:2]]
@@ -95,3 +100,6 @@ def main():
 
     score_combined(parser.parse_args().log, datetime.date.today())
     print('\nSee you next time!')
+
+if __name__ == '__main__':
+    main()

--- a/test/sitecustomize.py
+++ b/test/sitecustomize.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Enables code coverage for all Python processes, so that integration tests are included.
+'''
+
+import coverage
+coverage.process_startup()

--- a/test/test.py
+++ b/test/test.py
@@ -5,9 +5,15 @@ facere-sensum unit tests.
 '''
 
 import os
+import sys
+import subprocess # nosec B404
 import shutil
 import unittest
 import facere_sensum.facere_sensum as fs
+
+# Generate paths for test output and reference.
+_LOG = os.path.join('test', 'log.csv')
+_REF = os.path.join('test', 'ref.csv')
 
 def _setup_test_input(user_input):
     '''
@@ -26,25 +32,35 @@ class Test(unittest.TestCase):
         '''
         Test facere_sensum.score_combined function.
         '''
-        log = os.path.join('test', 'log.csv')
-
         # Minimal extreme: all metrics are zero.
         _setup_test_input([0,0,0])
-        fs.score_combined(log, 'A')
+        fs.score_combined(_LOG, 'A')
 
         # Maximal extreme: all metrics are one.
         _setup_test_input([1,1,1])
-        fs.score_combined(log, 'B')
+        fs.score_combined(_LOG, 'B')
 
         # Various values for metrics.
         _setup_test_input([.25,.5,.75])
-        fs.score_combined(log, 'C')
+        fs.score_combined(_LOG, 'C')
 
         # Compare with a reference.
-        with open(log, encoding='ascii') as log:
-            with open(os.path.join('test', 'ref.csv'), encoding='ascii') as ref:
+        with open(_LOG, encoding='ascii') as log:
+            with open(_REF, encoding='ascii') as ref:
                 self.assertEqual(log.readlines(), ref.readlines())
 
 if __name__ == '__main__':
+    print('Integration tests: ', end='')
+
+    # Log file not found test.
+    fs_py = ['python', os.path.join('src', 'facere_sensum', 'facere_sensum.py'), 'llog.csv']
+    res = subprocess.run(fs_py, check=False, capture_output=True, text=True).stdout # nosec B603
+    if res == 'Log file \'llog.csv\' not found. Exiting.\n':
+        print('OK')
+    else:
+        print('FAILED')
+        sys.exit(1)
+
+    # Unit tests
     shutil.copy('log.csv', 'test')
     unittest.main()


### PR DESCRIPTION
facere_sensum.py:
  - now fails gracefully if log file is not found
  - few other changes to enable code coverage computation
test.py:
  - cleaned up unit tests
  - added integration test to improve code coverage
  - 'nosec' comments suppress reviewed bandit security scanner warnings
sitecustomize.py - new file necessary for code coverage computation across several Python processes
.coveragerc - configuration for the code coverage tool
test.yaml - added code coverage computation
lints.yaml - added installation of the code coverage tool to keep pylint happy