### PR TITLE
Prepare for Adding Metrics That Require Authentication

### DIFF
--- a/auth.json
+++ b/auth.json
@@ -1,0 +1,6 @@
+{
+    "Google": {
+        "custom search API key": "",
+        "search engine ID": ""
+    }
+}

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "log": "log.csv",
     "metrics": [
         {
             "id": "Self-Development",

--- a/src/facere_sensum/facere_sensum.py
+++ b/src/facere_sensum/facere_sensum.py
@@ -136,25 +136,33 @@ def main():
     parser.add_argument('command', choices=['create', 'update'],
                         help='high-level action to perform')
     parser.add_argument('--version', action='version', version='%(prog)s '+VERSION)
+    parser.add_argument('--auth', nargs='?', help='authentication config')
     parser.add_argument('--config', nargs='?', default='config.json',
-                        help='metrics config (see README for details, default: config.json)')
-    parser.add_argument('--log', nargs='?', default='log.csv',
-                        help='CSV log file name (default: log.csv)')
+                        help='project config (default: config.json)')
     args = parser.parse_args()
+
+    if args.auth:
+        try :
+            with open(args.auth, encoding='utf-8') as auth:
+                auth = json.load(auth)
+        except FileNotFoundError:
+            print('Authentication config file \''+args.auth+'\' not found. Exiting.')
+            sys.exit(1)
 
     try:
         with open(args.config, encoding='utf-8') as config:
             config = json.load(config)
     except FileNotFoundError:
-        print('Config file \''+args.config+'\' not found. Exiting.')
+        print('Project config file \''+args.config+'\' not found. Exiting.')
         sys.exit(1)
 
+    log = config['log']
     if args.command == 'create':
-        command_create(config, args.log)
+        command_create(config, log)
     elif args.command == 'update':
-        command_update(config, args.log, datetime.date.today())
+        command_update(config, log, datetime.date.today())
         print('\nSee you next time!')
-    else:
+    else: # pragma: no cover
         # Should never get here given that all the actions are processed above.
         print('Something weird happened.',
               'Please submit an issue at https://github.com/lunarserge/facere-sensum/issues/new',

--- a/test/test.py
+++ b/test/test.py
@@ -71,18 +71,32 @@ class Test(unittest.TestCase):
         # Compare with a reference.
         self.assertTrue(_logs_equal(_LOG, _REF_UPDATED))
 
-if __name__ == '__main__':
-    print('Integration tests: ', end='')
-
-    # Log file not found test.
-    fs_py = ['python', os.path.join('src', 'facere_sensum', 'facere_sensum.py'),
-             '--log', 'llog.csv', 'update']
-    res = subprocess.run(fs_py, check=False, capture_output=True, text=True).stdout # nosec B603
-    if res == 'Log file \'llog.csv\' not found. Exiting.\n':
+def _test_integration(descr, args, ref):
+    '''
+    Run an integration test.
+    'descr' is test user description.
+    'args' command line arguments to use.
+    'ref' expected output.
+    '''
+    print(descr, end=': ')
+    res = subprocess.run(['python',
+                         os.path.join('src', 'facere_sensum', 'facere_sensum.py')] + args,
+                         check=False, capture_output=True, text=True).stdout # nosec B603
+    if res == ref:
         print('OK')
     else:
-        print('FAILED. Output:', res)
+        print('FAILED', 'Output:', '---', res, '---', 'Expected:', '---', ref, '---', sep='\n')
         sys.exit(1)
+
+if __name__ == '__main__':
+    print('Integration tests:')
+    _test_integration('Authentication config not found',
+                      ['--auth', 'aauth.json', 'update'],
+                      'Authentication config file \'aauth.json\' not found. Exiting.\n')
+    _test_integration('Project config not found',
+                      ['--config', 'cconfig.json', 'update'],
+                      'Project config file \'cconfig.json\' not found. Exiting.\n')
+    _test_integration('Create command', ['--auth', 'auth.json', 'create'], 'log.csv is created\n')
 
     # Unit tests
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -91,11 +91,11 @@ def _test_integration(descr, args, ref):
 if __name__ == '__main__':
     print('Integration tests:')
     _test_integration('Authentication config not found',
-                      ['--auth', 'aauth.json', 'update'],
-                      'Authentication config file \'aauth.json\' not found. Exiting.\n')
+                      ['--auth', 'notfound.json', 'update'],
+                      'Authentication config file \'notfound.json\' not found. Exiting.\n')
     _test_integration('Project config not found',
-                      ['--config', 'cconfig.json', 'update'],
-                      'Project config file \'cconfig.json\' not found. Exiting.\n')
+                      ['--config', 'notfound.json', 'update'],
+                      'Project config file \'notfound.json\' not found. Exiting.\n')
     _test_integration('Create command', ['--auth', 'auth.json', 'create'], 'log.csv is created\n')
 
     # Unit tests


### PR DESCRIPTION
1. Added auth.json as a blueprint for user credentials
2. Moved log file specification from the command line into the project config file

With these changes users can have:
- Multiple project config files that encapsulate both log file name and metrics spec
- Single credentials file shared across project configs