### PR TITLE
Initial GitHub Metrics

### DIFF
--- a/auth.json
+++ b/auth.json
@@ -1,4 +1,7 @@
 {
+    "GitHub": {
+        "personal access token": ""
+    },
     "Google": {
         "custom search API key": "",
         "search engine ID": ""

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -48,6 +48,52 @@ See `here <https://github.com/lunarserge/facere-sensum/tree/main/examples/config
 
 TO BE ADDED
 
+``GitHub``
+==========
+
+Captures metrics for GitHub projects. See subsections for specific metrics.
+
+GitHub does not require authenticated access, but rate limits are higher if a personal access token is provided. The personal access token can be provided using ``--auth`` command line option. Authentication JSON file needs to have the following entry::
+
+    "GitHub": {
+        "personal access token": "token goes here"
+    }
+
+See `here <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_github.json>`_ for an example of using GitHub data sources.
+
+``GitHub.star``
+---------------
+
+Captures number of GitHub stars against the target.
+
+JSON config fields for metrics using source ``GitHub.star``:
+
+* ``"source": "GitHub.star"``
+* ``"repo"`` (required): GitHub repository.
+* ``"target"`` (optional, defaults to ``1000``): target success number of GitHub stars for the metric value to hit ``0.5``.
+
+``GitHub.fork``
+---------------
+
+Captures number of GitHub forks against the target.
+
+JSON config fields for metrics using source ``GitHub.fork``:
+
+* ``"source": "GitHub.fork"``
+* ``"repo"`` (required): GitHub repository.
+* ``"target"`` (optional, defaults to ``100``): target success number of GitHub forks for the metric value to hit ``0.5``.
+
+``GitHub.watch``
+----------------
+
+Captures number of GitHub watchers against the target.
+
+JSON config fields for metrics using source ``GitHub.watch``:
+
+* ``"source": "GitHub.watch"``
+* ``"repo"`` (required): GitHub repository.
+* ``"target"`` (optional, defaults to ``50``): target success number of GitHub watchers for the metric value to hit ``0.5``.
+
 ``user``
 ========
 

--- a/examples/config_github.json
+++ b/examples/config_github.json
@@ -1,0 +1,25 @@
+{
+    "log": "log.csv",
+    "metrics": [
+        {
+            "id": "stars",
+            "priority": 0.333,
+            "source": "GitHub.star",
+            "repo": "lunarserge/facere-sensum"
+        },
+        {
+            "id": "forks",
+            "priority": 0.333,
+            "source": "GitHub.fork",
+            "repo": "lunarserge/facere-sensum",
+            "target": 10
+        },
+        {
+            "id": "watchers",
+            "priority": 0.333,
+            "source": "GitHub.watch",
+            "repo": "lunarserge/facere-sensum",
+            "target": 5
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
   numpy>=1.24.3
   pandas>=2.0.1
   prettytable>=3.9.0
+  PyGithub>=1.59.1

--- a/src/facere_sensum/connectors/GitHub/_github.py
+++ b/src/facere_sensum/connectors/GitHub/_github.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Common functionality for GitHub data connectors.
+'''
+
+import github
+from facere_sensum import fs
+
+_token = fs.get_3rd_party_entry('GitHub', 'personal access token')
+g = github.Github(auth = github.Auth.Token(_token) if _token else None)
+
+def get_normalized(metric, raw, target):
+    '''
+    Get standard (i.e., normalized) metric score for a GitHub metric.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    'target' is the success target for the normalized metric to hit 0.5 mark.
+    '''
+    if 'target' in metric:
+        target = metric['target']
+    perfect = target * 2
+    return 1 if raw >= perfect else raw/perfect

--- a/src/facere_sensum/connectors/GitHub/fork.py
+++ b/src/facere_sensum/connectors/GitHub/fork.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for GitHub forks.
+'''
+
+from . import _github as gh
+
+# Default success target for GutHub forks.
+_TARGET = 100
+
+def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
+    '''
+    Get raw metric score for GitHub forks: their number.
+    'metric' is the metric JSON description.
+    '''
+    return gh.g.get_repo(metric['repo']).forks_count
+
+def get_normalized(metric, raw):
+    '''
+    Get standard (i.e., normalized) metric score for GitHub forks.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    '''
+    return gh.get_normalized(metric,raw,_TARGET)

--- a/src/facere_sensum/connectors/GitHub/star.py
+++ b/src/facere_sensum/connectors/GitHub/star.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for GitHub stars.
+'''
+
+from . import _github as gh
+
+# Default success target for GutHub stars.
+_TARGET = 1000
+
+def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
+    '''
+    Get raw metric score for GitHub stars: their number.
+    'metric' is the metric JSON description.
+    '''
+    return gh.g.get_repo(metric['repo']).stargazers_count
+
+def get_normalized(metric, raw):
+    '''
+    Get standard (i.e., normalized) metric score for GitHub stars.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    '''
+    return gh.get_normalized(metric,raw,_TARGET)

--- a/src/facere_sensum/connectors/GitHub/watch.py
+++ b/src/facere_sensum/connectors/GitHub/watch.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for number of GitHub watchers.
+'''
+
+from . import _github as gh
+
+# Default success target for GutHub watchers.
+_TARGET = 50
+
+def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
+    '''
+    Get raw metric score for GitHub watchers: their number.
+    'metric' is the metric JSON description.
+    '''
+    return gh.g.get_repo(metric['repo']).subscribers_count
+
+def get_normalized(metric, raw):
+    '''
+    Get standard (i.e., normalized) metric score for GitHub watchers.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    '''
+    return gh.get_normalized(metric,raw,_TARGET)

--- a/src/facere_sensum/fs.py
+++ b/src/facere_sensum/fs.py
@@ -151,6 +151,21 @@ def command_update(config, log_file, marker):
     print(log_file, 'is updated')
     return score_comb
 
+def get_3rd_party_entry(party, entry):
+    '''
+    Get 3rd parthy entry from the authentication config.
+    'party' is the 3rd party name.
+    'entry' is the entry name.
+    Return the requested entry if it is specified via the authentication config, None otherwise.
+    '''
+    if not 'auth' in globals():
+        return None # No authentication config at all.
+    config = globals()['auth']
+    if not party in config:
+        return None # No authentication info for the specified 3rd party.
+    party = config[party]
+    return party[entry] if entry in party else None
+
 def main():
     '''
     CLI entry.

--- a/test/t_connectors/GitHub/t_fork.py
+++ b/test/t_connectors/GitHub/t_fork.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for GitHub forks - testing support.
+'''
+
+from os import path
+import json
+from facere_sensum.connectors.GitHub import fork
+
+def test():
+    '''
+    Test GitHub forks data connector.
+    Return True if the test was successful, False otherwise.
+    '''
+    # Metric from examples.
+    with open(path.join('examples', 'config_github.json'), encoding='utf-8') as config_file:
+        metric0 = json.load(config_file)['metrics'][1]
+
+    metric1 = {
+        'id': 'test case for forks with default target',
+        'source': 'GitHub.fork',
+        'repo': 'lunarserge/facere-sensum'
+    }
+    metric2 = {
+        'id': 'test case for forks with specified target',
+        'source': 'GitHub.fork',
+        'repo': 'lunarserge/facere-sensum',
+        'target': 10
+    }
+
+    return fork.get_normalized(metric0, 10) == .5 and \
+        fork.get_normalized(metric1, 10) == .05 and \
+        fork.get_normalized(metric2, 1) == .05

--- a/test/t_connectors/GitHub/t_star.py
+++ b/test/t_connectors/GitHub/t_star.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for GitHub stars - testing support.
+'''
+
+from os import path
+import json
+from facere_sensum.connectors.GitHub import star
+
+def test():
+    '''
+    Test GitHub stars data connector.
+    Return True if the test was successful, False otherwise.
+    '''
+    # Metric from examples.
+    with open(path.join('examples', 'config_github.json'), encoding='utf-8') as config_file:
+        metric0 = json.load(config_file)['metrics'][0]
+
+    metric1 = {
+        'id': 'test case for stars with default target',
+        'source': 'GitHub.star',
+        'repo': 'lunarserge/facere-sensum'
+    }
+    metric2 = {
+        'id': 'test case for stars with specified target',
+        'source': 'GitHub.star',
+        'repo': 'lunarserge/facere-sensum',
+        'target': 10
+    }
+
+    return star.get_normalized(metric0, 100) == .05 and \
+        star.get_normalized(metric1, 10) == .005 and \
+        star.get_normalized(metric2, 1) == .05

--- a/test/t_connectors/GitHub/t_watch.py
+++ b/test/t_connectors/GitHub/t_watch.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for GitHub watchers - testing support.
+'''
+
+from os import path
+import json
+from facere_sensum.connectors.GitHub import watch
+
+def test():
+    '''
+    Test GitHub watchers data connector.
+    Return True if the test was successful, False otherwise.
+    '''
+    # Metric from examples.
+    with open(path.join('examples', 'config_github.json'), encoding='utf-8') as config_file:
+        metric0 = json.load(config_file)['metrics'][2]
+
+    metric1 = {
+        'id': 'test case for watchers with default target',
+        'source': 'GitHub.watch',
+        'repo': 'lunarserge/facere-sensum'
+    }
+    metric2 = {
+        'id': 'test case for watchers with specified target',
+        'source': 'GitHub.watch',
+        'repo': 'lunarserge/facere-sensum',
+        'target': 10
+    }
+
+    return watch.get_normalized(metric0, 20) == 1 and \
+        watch.get_normalized(metric1, 10) == .1 and \
+        watch.get_normalized(metric2, 1) == .05

--- a/test/test.py
+++ b/test/test.py
@@ -83,9 +83,17 @@ class Test(unittest.TestCase):
         with open('auth.json', encoding='utf-8') as auth_file:
             fs.auth = json.load(auth_file)
 
-        for file_name in os.listdir(os.path.join('test', 't_connectors')):
-            if file_name.startswith('t_') and file_name.endswith('.py'):
-                self.assertTrue(importlib.import_module('t_connectors.t_'+file_name[2:-3]).test())
+        # pylint: disable-next=unused-variable
+        for dir_path, dir_names, file_names in os.walk(os.path.join('test', 't_connectors')):
+            if dir_path.endswith('__pycache__'):
+                continue
+
+            # Remove leading 'test' folder and convert to package syntax.
+            dir_path = dir_path[5:].replace(os.sep,'.')
+
+            for file_name in file_names:
+                if file_name.startswith('t_') and file_name.endswith('.py'):
+                    self.assertTrue(importlib.import_module(dir_path+'.'+file_name[:-3]).test())
 
 def _test_integration(descr, args, ref_out, ref_err):
     '''


### PR DESCRIPTION
`src/facere_sensum/fs.py`: added a function to conveniently access 3rd party authentication info
`src/facere_sensum/connectors/GitHub/_github.py`, `src/facere_sensum/connectors/GitHub/star.py`, `src/facere_sensum/connectors/GitHub/_fork.py`, `src/facere_sensum/connectors/GitHub/watch.py`: implementation for GitHub stars/forks/watchers data sources
`test/t_connectors/GitHub/t_star.py`, `test/t_connectors/GitHub/t_fork.py`, `test/t_connectors/GitHub/t_watch.py`: tests for the above
`test/test.py`: updated test walker to look into subfolders (as GitHub tests are in their own subfolder)
`doc/sources.rst`: updated docs with GitHub data sources info
`examples/config_github.json`: example to complement docs
`auth.json`: added placeholder for GitHub authentication
`requirements.txt`: added PyGithub dependency