### PR TITLE
'uptodate' metric source

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -43,18 +43,6 @@ See `Custom Search JSON API <https://developers.google.com/custom-search/v1/over
 
 See `customsearch JSON config <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_customsearch.json>`_ for an example of using the ``customsearch`` data source.
 
-``uplevel``
-===========
-
-Uplevels collective metric behavior to a higher-level via computing the weighted sum of the corresponding lower-level metric values. This data source supports key ``facere-sensum`` idea of combining metrics into tree-like structures. See :ref:`here <the-approach>` for details.
-
-JSON config fields for metrics using source ``uplevel``:
-
-* ``"source": "uplevel"``
-* ``"log"`` (required): CSV file storing the data for ``facere-sensum`` layer that is being upleveled.
-
-See `uplevel JSON config <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_uplevel.json>`_ for an example of using the ``uplevel`` data source.
-
 ``GitHub``
 ==========
 
@@ -100,6 +88,31 @@ JSON config fields for metrics using source ``GitHub.watch``:
 * ``"source": "GitHub.watch"``
 * ``"repo"`` (required): GitHub repository.
 * ``"target"`` (optional, defaults to ``50``): target success number of GitHub watchers for the metric value to hit ``0.5``.
+
+``uplevel``
+===========
+
+Uplevels collective metric behavior to a higher-level via computing the weighted sum of the corresponding lower-level metric values. This data source supports key ``facere-sensum`` idea of combining metrics into tree-like structures. See :ref:`here <the-approach>` for details.
+
+JSON config fields for metrics using source ``uplevel``:
+
+* ``"source": "uplevel"``
+* ``"log"`` (required): CSV file storing the data for ``facere-sensum`` layer that is being upleveled.
+
+See `uplevel JSON config <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_uplevel.json>`_ for an example of using the ``uplevel`` data source.
+
+``uptodate``
+============
+
+Tracks assets to be up to date by calculating number of days passed since an asset was updated last time. The date of the asset's last update should be manually corrected in the config file if the asset receives an update. This metric is useful, e.g., for tracking products that need their collateral regularly updated.
+
+JSON config fields for metrics using source ``uptodate``:
+
+* ``"source": "uptodate"``
+* ``"updated"`` (required): string in ISO 8601 format representing the date when the asset was updated last time.
+* ``"target"`` (optional, defaults to ``365``): number of days passed for the metric normalized score to hit ``0.5``. The normalized score will be above ``0.5`` for newer assets and below ``0.5`` for older assets.
+
+See `uptodate JSON config <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_uptodate.json>`_ for an example of using the ``uptodate`` data source.
 
 ``user``
 ========

--- a/examples/config_uptodate.json
+++ b/examples/config_uptodate.json
@@ -1,0 +1,24 @@
+{
+    "log": "log.csv",
+    "metrics": [
+        {
+            "id": "From Late Nov",
+            "priority": 0.3,
+            "source": "uptodate",
+            "updated": "2023-11-21"
+        },
+        {
+            "id": "From Start of Feb",
+            "priority": 0.3,
+            "source": "uptodate",
+            "updated": "2024-02-01",
+            "target": 100
+        },
+        {
+            "id": "From Long Time Back",
+            "priority": 0.4,
+            "source": "uptodate",
+            "updated": "2021-02-02"
+        }
+    ]
+}

--- a/src/facere_sensum/connectors/uptodate.py
+++ b/src/facere_sensum/connectors/uptodate.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for tracking assets to be up-to-date.
+'''
+
+from datetime import date
+
+# Default success target for an up-to-date asset: no older than one year.
+_TARGET = 365
+
+def today():
+    '''
+    Get today's date.
+    This function is to support testing by overriding it with a static date.
+    Can't override date.today directly since datetime.date is immutable.
+    '''
+    return date.today()
+
+def get_raw(metric):
+    '''
+    Get metric score as number of days passed since the specified date.
+    'metric' is the metric JSON description.
+    '''
+    return (today()-date.fromisoformat(metric['updated'])).days
+
+def get_normalized(metric, raw):
+    '''
+    Get standard (i.e., normalized) metric score for tracking assets to be up-to-date.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    '''
+    target = metric['target'] if 'target' in metric else _TARGET
+    outdated = target * 2
+    return 0 if raw >= outdated else (outdated-raw)/outdated

--- a/test/t_connectors/t_uptodate.py
+++ b/test/t_connectors/t_uptodate.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for tracking assets to be up-to-date - testing support.
+'''
+
+from os import path
+import json
+from datetime import date
+from facere_sensum.connectors import uptodate
+
+def test():
+    '''
+    Test the data connector for tracking assets to be up-to-date.
+    Return True if the test was successful, False otherwise.
+    '''
+    # Test the metrics from examples.
+    with open(path.join('examples', 'config_uptodate.json'), encoding='utf-8') as config_file:
+        metrics = json.load(config_file)['metrics']
+
+    # Override today's date with a static date so that we get predictable test result.
+    save = uptodate.today
+    uptodate.today = lambda: date(2024,2,2)
+
+    res = True
+    for m,r,n in zip(metrics,[73,1,1095],[0.9,0.995,0]):
+        raw = uptodate.get_raw(m)
+        if raw != r or uptodate.get_normalized(m, r) != n:
+            res = False
+            break
+
+    uptodate.today = save
+    return res


### PR DESCRIPTION
Start from 'doc/sources.rst' - documentation change that explains the rest of this pull request.

- uptodate.py - implementation
- t_uptodate.py - unit test
- config_uptodate.json - example (also used in test)

Additionally: moved 'uplevel' data source down in the documentation so that data sources are in the alphabet order.