### PR TITLE
'validlink' metric source

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -119,6 +119,25 @@ Layer config fields for metrics using source ``user``:
 
 The ``user`` metric source does not utilize any additional fields.
 
+``validlink``
+=============
+
+Tracks the validity of web page links by checking if the URL produces a 404 error.
+
+The raw metric score is calculated as follows:
+
+* ``0`` if accessing the web page with the URL produces a 404 error.
+* ``1`` otherwise.
+
+The normalized score is the same as the raw score.
+
+Layer config fields for metrics using source ``validlink``:
+
+* ``"source"``: ``"validlink"``
+* ``"URL"`` (required): URL of the web page to track.
+
+See `validlink layer config <https://github.com/lunarserge/facere-sensum/tree/main/examples/config_validlink.json>`_ for an example of using the ``validlink`` metric source.
+
 .. _bringing-your-own-metric:
 
 ************************

--- a/examples/config_validlink.json
+++ b/examples/config_validlink.json
@@ -1,0 +1,10 @@
+{
+    "log": "log_validlink.csv",
+    "metrics": [
+        {
+            "id": "example validlink",
+            "source": "validlink",
+            "URL": "https://www.example.com/"
+        }
+    ]
+}

--- a/src/facere_sensum/connectors/validlink.py
+++ b/src/facere_sensum/connectors/validlink.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for ValidLink.
+'''
+
+import requests
+
+def get_raw(metric):
+    '''
+    Get raw metric score for ValidLink:
+    0 if URL produces a 404 error, 1 otherwise.
+    'metric' is the metric JSON description.
+    '''
+    url = metric['URL']
+    try:
+        response = requests.head(url)
+        return 0 if response.status_code == 404 else 1
+    except requests.RequestException:
+        return 0
+
+def get_normalized(metric, raw):
+    '''
+    Get standard (i.e., normalized) metric score for ValidLink.
+    'metric' is the metric JSON description.
+    'raw' is the raw metric score.
+    '''
+    return raw

--- a/test/t_connectors/t_validlink.py
+++ b/test/t_connectors/t_validlink.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+
+'''
+Data connector for ValidLink - testing support.
+'''
+
+from facere_sensum.connectors import validlink
+
+def test():
+    '''
+    Test ValidLink data connector.
+    Return True if the test was successful, False otherwise.
+    '''
+    metric1 = {
+        'id': 'test case for valid URL',
+        'source': 'validlink',
+        'URL': 'https://www.example.com/'
+    }
+    metric2 = {
+        'id': 'test case for 404 URL',
+        'source': 'validlink',
+        'URL': 'https://www.example.com/404'
+    }
+
+    return validlink.get_raw(metric1) == 1 and \
+        validlink.get_raw(metric2) == 0 and \
+        validlink.get_normalized(metric1, 1) == 1 and \
+        validlink.get_normalized(metric2, 0) == 0


### PR DESCRIPTION
Related to #41

Implement the 'validlink' metric source to track web page link validity.

* **New Metric Source:**
  - Add `src/facere_sensum/connectors/validlink.py` to implement the 'validlink' metric source.
  - Implement `get_raw(metric)` to return 0 if URL produces a 404 error, 1 otherwise.
  - Implement `get_normalized(metric, raw)` to return the same value as `raw`.

* **Documentation:**
  - Update `doc/sources.rst` to include documentation for 'validlink' metric source.
  - Describe the raw and normalized score computation.
  - Include details about the required 'URL' field.

* **Usage Example:**
  - Add `examples/config_validlink.json` to provide a usage example for 'validlink' metric source.
  - Include a sample URL to track.

* **Unit Tests:**
  - Add `test/t_connectors/t_validlink.py` to include unit tests for 'validlink' metric source.
  - Test `get_raw(metric)` for both 404 and non-404 URLs.
  - Test `get_normalized(metric, raw)` for both 0 and 1 raw scores.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lunarserge/facere-sensum/issues/41?shareId=a9565e96-9f4c-403c-865c-d36467ae7b7a).

PS creating it as a draft PR to be able to run workflows. I also don't really understand that changes yet.