### PR TITLE
Fixed typo in README package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Comprehensive documentation is available [here](https://lunarserge.github.io/fac
 
 # Usage
 
-    facere_sensum [-h] [--version] [--auth [AUTH]] [--config [CONFIG]] {create,update,chart}
+    facere-sensum [-h] [--version] [--auth [AUTH]] [--config [CONFIG]] {create,update,chart}
 
 {**create**,**update**,**chart**}: high-level action to perform
 


### PR DESCRIPTION
I corrected the usage section in the _README_ file where the package name was incorrectly mentioned as **facere_sensum**. The correct package name is **facere-sensum**.