### PR TITLE
Enabling 'black' source checker

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Black code format checker
         run: |
           pip install black
-          black --check src/facere_sensum/connectors/GitHub/_github.py
+          black --check src/facere_sensum/connectors/GitHub
       - name: Run Pylint static code analyser
         run: |
           pip install coverage pylint

--- a/src/facere_sensum/connectors/GitHub/fork.py
+++ b/src/facere_sensum/connectors/GitHub/fork.py
@@ -1,25 +1,29 @@
 # SPDX-License-Identifier: MIT
 
-'''
-Data connector for GitHub forks.
-'''
+"""
+Metric source for GitHub forks.
+"""
 
 from . import _github as gh
 
 # Default success target for GutHub forks.
 _TARGET = 100
 
-def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
-    '''
+
+def get_raw(
+    metric,
+):  # pragma: no cover - can't test REST API response changing over time.
+    """
     Get raw metric score for GitHub forks: their number.
-    'metric' is the metric JSON description.
-    '''
-    return gh.g.get_repo(metric['repo']).forks_count
+    'metric' is the metric definition.
+    """
+    return gh.g.get_repo(metric["repo"]).forks_count
+
 
 def get_normalized(metric, raw):
-    '''
-    Get standard (i.e., normalized) metric score for GitHub forks.
-    'metric' is the metric JSON description.
+    """
+    Get normalized metric score for GitHub forks.
+    'metric' is the metric definition.
     'raw' is the raw metric score.
-    '''
-    return gh.get_normalized(metric,raw,_TARGET)
+    """
+    return gh.get_normalized(metric, raw, _TARGET)

--- a/src/facere_sensum/connectors/GitHub/star.py
+++ b/src/facere_sensum/connectors/GitHub/star.py
@@ -1,25 +1,29 @@
 # SPDX-License-Identifier: MIT
 
-'''
-Data connector for GitHub stars.
-'''
+"""
+Metric source for GitHub stars.
+"""
 
 from . import _github as gh
 
 # Default success target for GutHub stars.
 _TARGET = 1000
 
-def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
-    '''
+
+def get_raw(
+    metric,
+):  # pragma: no cover - can't test REST API response changing over time.
+    """
     Get raw metric score for GitHub stars: their number.
-    'metric' is the metric JSON description.
-    '''
-    return gh.g.get_repo(metric['repo']).stargazers_count
+    'metric' is the metric definition.
+    """
+    return gh.g.get_repo(metric["repo"]).stargazers_count
+
 
 def get_normalized(metric, raw):
-    '''
-    Get standard (i.e., normalized) metric score for GitHub stars.
-    'metric' is the metric JSON description.
+    """
+    Get normalized metric score for GitHub stars.
+    'metric' is the metric definition.
     'raw' is the raw metric score.
-    '''
-    return gh.get_normalized(metric,raw,_TARGET)
+    """
+    return gh.get_normalized(metric, raw, _TARGET)

--- a/src/facere_sensum/connectors/GitHub/watch.py
+++ b/src/facere_sensum/connectors/GitHub/watch.py
@@ -1,25 +1,29 @@
 # SPDX-License-Identifier: MIT
 
-'''
-Data connector for number of GitHub watchers.
-'''
+"""
+Metric source for GitHub watchers.
+"""
 
 from . import _github as gh
 
 # Default success target for GutHub watchers.
 _TARGET = 50
 
-def get_raw(metric): # pragma: no cover - can't test REST API response changing over time.
-    '''
+
+def get_raw(
+    metric,
+):  # pragma: no cover - can't test REST API response changing over time.
+    """
     Get raw metric score for GitHub watchers: their number.
-    'metric' is the metric JSON description.
-    '''
-    return gh.g.get_repo(metric['repo']).subscribers_count
+    'metric' is the metric definition.
+    """
+    return gh.g.get_repo(metric["repo"]).subscribers_count
+
 
 def get_normalized(metric, raw):
-    '''
-    Get standard (i.e., normalized) metric score for GitHub watchers.
-    'metric' is the metric JSON description.
+    """
+    Get normalized metric score for GitHub watchers.
+    'metric' is the metric definition.
     'raw' is the raw metric score.
-    '''
-    return gh.get_normalized(metric,raw,_TARGET)
+    """
+    return gh.get_normalized(metric, raw, _TARGET)


### PR DESCRIPTION
- enable source formatting for everything in src/facere_sensum/connectors/GitHub folder
- cosmetic changes to better follow project terminology