### PR TITLE
Enable source formatting for src/facere_sensum/connectors/customsearch

### DIFF
--- a/doc/features.rst
+++ b/doc/features.rst
@@ -9,6 +9,8 @@ Key features of ``facere-sensum`` include:
 * Automatic computation of higher-level metrics to capture the overall behavior of metrics collectively.
 * Creation of charts to visualize the behavior of metrics over time.
 
+.. _layers:
+
 ******
 Layers
 ******

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -37,7 +37,8 @@ Layer config fields for metrics using source ``customsearch``:
 
 * ``"source"``: ``"customsearch"``
 * ``"URL"`` (required): Target web page.
-* ``"num"`` (optional, defaults to ``50``): Number of search results to consider.
+* ``"q"`` (optional, defaults to :ref:`metric id <layers>`): Search phrase.
+* ``"num"`` (optional, defaults to ``20``): Number of search results to consider.
 
 Since this source accesses Google services, authentication details must be provided using the ``--auth`` command line option. Authentication config needs to have the following entry::
 

--- a/src/facere_sensum/connectors/customsearch.py
+++ b/src/facere_sensum/connectors/customsearch.py
@@ -1,60 +1,70 @@
 # SPDX-License-Identifier: MIT
 
-'''
-Data connector for Google Custom Search API.
-'''
+"""
+Metric source for Google Custom Search API.
+"""
 
 from googleapiclient.discovery import build
 from facere_sensum import fs
 
-# Default for number of search results to consider.
-_NUM = 50
+# Default number of search results to consider.
+_NUM = 20
 
-_auth = fs.auth['Google']
-_cse = build('customsearch', 'v1', developerKey=_auth['custom search API key']).cse() # pylint: disable=E1101
+_auth = fs.auth["Google"]
+_cse = build(  # pylint: disable=E1101
+    "customsearch", "v1", developerKey=_auth["custom search API key"]
+).cse()
 
-def invoke_cse(query, start): # pragma: no cover
-    '''
+
+def invoke_cse(
+    query,
+    start,
+):  # pragma: no cover
+    """
     Invoke Custom Search API with specified query and index of the first result to return.
     Keep this function separate so that testing scripts can substitute with a mockup.
-    '''
-    return _cse.list(q=query, cx=_auth['search engine ID'], start=start).execute()
+    """
+    return _cse.list(q=query, cx=_auth["search engine ID"], start=start).execute()
+
 
 def get_raw(metric):
-    '''
+    """
     Get raw metric score for Google Custom Search API:
     rank of the query or zero, if it didn't appear in search results.
-    'metric' is the metric JSON description.
-    '''
-    query = metric['q'] if 'q' in metric else metric['id']
-    num = metric['num'] if 'num' in metric else _NUM
-    url = metric['URL']
+    'metric' is the metric definition.
+    """
+    query = metric["q"] if "q" in metric else metric["id"]
+    num = metric["num"] if "num" in metric else _NUM
+    url = metric["URL"]
 
     start = 1
     while num > 0:
         res = invoke_cse(query, start)
 
-        for (index,item) in enumerate(res['items'][:num]):
-            if item['link'] == url:
-                return start+index
+        for index, item in enumerate(res["items"][:num]):
+            if item["link"] == url:
+                return start + index
 
-        if 'nextPage' not in res['queries']:
-            print('Warning (Google Custom Search API connector): ' \
-                  f'query "{query}" produced small number of search results')
+        if "nextPage" not in res["queries"]:
+            print(
+                "Warning (customsearch metric source): "
+                f"query '{query}' produced small number of search results"
+            )
             return 0
 
         start += 10
         num -= 10
     return 0
 
+
 def get_normalized(metric, raw):
-    '''
-    Get standard (i.e., normalized) metric score for Google Custom Search API.
-    'metric' is the metric JSON description.
+    """
+    Get normalized metric score for Google Custom Search API.
+    'metric' is the metric definition.
     'raw' is the raw metric score.
-    '''
+    """
     if raw:
-        num = metric['num'] if 'num' in metric else _NUM
-        return (num+1-raw) / num
+        num = metric["num"] if "num" in metric else _NUM
+        return (num + 1 - raw) / num
 
     return 0

--- a/test/t_connectors/t_customsearch.py
+++ b/test/t_connectors/t_customsearch.py
@@ -48,4 +48,4 @@ def test():
         'URL': 'https://www.notfound.com/'
     }
 
-    return _test(metric1, 4, 0.94) & _test(metric2, 0, 0)
+    return _test(metric1, 4, 0.85) & _test(metric2, 0, 0)


### PR DESCRIPTION
- Enable source format for src/facere_sensum/connectors/customsearch (actual enforcement in CI to follow once I finish all the connectors)
- Cosmetic changes to better follow project terminology
- Documented 'q' config field which was in the code, but not reflected in the docs ('q' is not very descriptive, but matches Google API)
- Decreased the default value of 'num' from 50 to 20, so that the default supports success definition as being found on the first page of Google search results
- Updated the unit test to reflect the default value change